### PR TITLE
Upgrade ex2ms

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule WallEx.Mixfile do
       {:plug, "~> 1.7"},
       {:jason, "~> 1.0"},
       {:dialyxir, "~> 0.5.1", only: [:dev], runtime: false},
-      {:ex2ms, "~> 1.5"}
+      {:ex2ms, "~> 1.6.1"}
     ]
   end
 end


### PR DESCRIPTION
Fixes this compile error:
```== Compilation error in file lib/wall_ex/storage.ex ==
** (KeyError) key :vars not found in: #Macro.Env<aliases: [], context: nil, context_modules: [WallEx.Storage], file: "g:/Git/wall_ex/lib/wall_ex/storage.ex", function: {:expiration_match_spec, 0}, functions: [{Kernel, [!=: 2, !==: 2, *: 2, **: 2, +: 1, +: 2, ++: 2, -: 1, -: 2, --: 2, /: 2, <: 2, <=: 2, ==: 2, ===: 2, =~: 2, >: 2, >=: 2, abs: 1, apply: 2, apply: 3, binary_part: 3, bit_size: 1, byte_size: 1, ceil: 1, div: 2, elem: 2, exit: 1, floor: 1, function_exported?: 3, get_and_update_in: 3, get_in: 2, hd: 1, inspect: 1, inspect: 2, is_atom: 1, is_binary: 1, is_bitstring: 1, is_boolean: 1, is_float: 1, is_function: 1, ...]}], lexical_tracker: #PID<0.271.0>, line: 65, macro_aliases: [], macros: [{Ex2ms, [fun: 1]}, {Kernel, [!: 1, &&: 2, ..: 2, ..//: 3, <>: 2, @: 1, alias!: 1, and: 2, binding: 0, binding: 1, def: 1, def: 2, defdelegate: 2, defexception: 1, defguard: 1, defguardp: 1, defimpl: 2, defimpl: 3, defmacro: 1, defmacro: 2, defmacrop: 1, defmacrop: 2, defmodule: 2, defoverridable: 1, defp: 1, defp: 2, defprotocol: 2, defstruct: 1, destructure: 2, get_and_update_in: 2, if: 2, in: 2, is_exception: 1, is_exception: 2, is_nil: 1, is_struct: 1, ...]}], module: WallEx.Storage, requires: [Application, Ex2ms, Kernel, Kernel.Typespec], ...>
    (ex2ms 1.6.0) lib/ex2ms.ex:206: Ex2ms.translate_param/2
    (ex2ms 1.6.0) lib/ex2ms.ex:184: Ex2ms.translate_head/2
    (ex2ms 1.6.0) lib/ex2ms.ex:116: Ex2ms.translate_clause/2
    (elixir 1.13.4) lib/enum.ex:1593: Enum."-map/2-lists^map/1-0-"/2
    (ex2ms 1.6.0) expanding macro: Ex2ms.fun/1
    lib/wall_ex/storage.ex:65: WallEx.Storage.expiration_match_spec/0
```
See https://github.com/elixir-lang/elixir/issues/11367